### PR TITLE
Adding important missing "out" text

### DIFF
--- a/privacy_hipaa.mdx
+++ b/privacy_hipaa.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Privacy"
 description: "Learn how to ensure privacy when using Vapi's voice assistant platform."
 ---
 
-By Default Vapi records your calls, logs or transcriptions for the purpose of improving the quality of the service. At the same time we respect your privacy and so you can opt by choosing HIPAA Compliance. This does have its own drawback in the sense that you will not be able to access the logs, recordings or transcriptions of the call.
+By Default Vapi records your calls, logs or transcriptions for the purpose of improving the quality of the service. At the same time we respect your privacy and so you can opt-out by choosing HIPAA Compliance. This does have its own drawback in the sense that you will not be able to access the logs, recordings or transcriptions of the call.
 
 ## HIPAA Compliance with Vapi
 


### PR DESCRIPTION
Assuming this sentence was supposed to explain how to opt-out of the recordings, it was missing the explicit and all-important "out".