### PR TITLE
Fix typo in Dashboard Doc

### DIFF
--- a/dashboard.mdx
+++ b/dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-title: "The Sidebar"
+title: "The Dashboard"
 sidebarTitle: "Dashboard"
 description: "Build Voicebots in Minutes in a Self-Service Dashboard"
 ---


### PR DESCRIPTION
- Change "Sidebar" to "Dashboard" in sidebarTitle