### PR TITLE
Path Homepage Links

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -19,7 +19,7 @@ We built Vapi so you didn’t have to. Everything developers need to immediately
 
 <Accordion title="Customizations and Integrations">
 
-Vapi lets you use our voice assistants on every platform. For example, mobile app developers can use [Client SDKs](docs.vapi.ai/clients) to add a Vapi voice assistant to web apps and iOS apps. And we offer multiple ways to get under the hood and further customize your voice assistant, e.g., [Custom LLMs](docs.vapi.ai/custom_llm), more advanced [Call Functions](docs.vapi.ai/call_functions), and [Persistent Assistants](docs.vapi.ai/persistent_assistants).
+Vapi lets you use our voice assistants on every platform. For example, mobile app developers can use [Client SDKs](https://docs.vapi.ai/clients) to add a Vapi voice assistant to web apps and iOS apps. And we offer multiple ways to get under the hood and further customize your voice assistant, e.g., [Custom LLMs](https://docs.vapi.ai/custom_llm), more advanced [Call Functions](https://docs.vapi.ai/call_functions), and [Persistent Assistants](https://docs.vapi.ai/persistent_assistants).
 
 </Accordion>
 


### PR DESCRIPTION
Patches links under "Customizations and Integrations" Accordion to now navigate to the proper page:

**Before**
![before](https://github.com/VapiAI/docs/assets/31268101/f63e6cd1-0e98-43de-b7d8-e71bf48e2df6)

**After**
![after](https://github.com/VapiAI/docs/assets/31268101/6fe061e0-2b04-4aab-8ae2-0e1daef39798)
