### PR TITLE
Fix odd item formatting on multilingual introduction

### DIFF
--- a/multilingual.mdx
+++ b/multilingual.mdx
@@ -29,7 +29,8 @@ Vapi currently supports the following providers for text-to-speech:
 - `Azure`
 - `Lmnt`
 - `Neets`
-  Each provider offers varying degrees of language support. Azure, for instance, supports the most languages, with approximately 400 prebuilt voices across 140 languages and variants. You can also create your own custom languages with other providers.
+
+Each provider offers varying degrees of language support. Azure, for instance, supports the most languages, with approximately 400 prebuilt voices across 140 languages and variants. You can also create your own custom languages with other providers.
 
 ## Multilingual Support
 


### PR DESCRIPTION
Right now, it shows up as part of the last item; I don't think that's supposed to happen.